### PR TITLE
feat: サイト全体をモノトーン・シンプルデザインに変更

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './.next/dev/types/routes.d.ts'
+import './.next/types/routes.d.ts'
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/about/about.module.css
+++ b/src/app/about/about.module.css
@@ -47,7 +47,7 @@
   top: 0;
   bottom: 0;
   width: 3px;
-  background: var(--gradient-primary);
+  background: var(--color-border);
   border-radius: var(--radius-full);
 }
 
@@ -68,7 +68,7 @@
   top: 4px;
   width: 16px;
   height: 16px;
-  background: var(--gradient-primary);
+  background: var(--color-text);
   border: 3px solid var(--color-bg);
   border-radius: 50%;
   box-shadow: 0 0 0 3px var(--border-color);
@@ -86,7 +86,7 @@
 
 .careerCard:hover {
   transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(102, 126, 234, 0.15);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
 }
 
 /* Header Section */
@@ -116,10 +116,7 @@
   font-weight: var(--font-weight-bold);
   line-height: 1.3;
   margin-bottom: var(--spacing-xs);
-  background: var(--gradient-primary);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  color: var(--text-primary);
 }
 
 .roleText {
@@ -182,8 +179,8 @@
 }
 
 .techTag {
-  background: var(--gradient-primary);
-  color: white;
+  background-color: var(--color-text);
+  color: var(--color-bg);
 }
 
 /* Dark mode adjustments */
@@ -193,7 +190,7 @@
 }
 
 :root[data-theme='dark'] .careerCard:hover {
-  box-shadow: 0 4px 12px rgba(102, 126, 234, 0.3);
+  box-shadow: 0 4px 12px rgba(255, 255, 255, 0.1);
 }
 
 :root[data-theme='dark'] .responsibilityTag {

--- a/src/app/contact/contact.module.css
+++ b/src/app/contact/contact.module.css
@@ -27,8 +27,8 @@
 .formLink {
   display: inline-block;
   padding: var(--spacing-sm) var(--spacing-lg);
-  background: var(--gradient-primary);
-  color: white;
+  background-color: var(--color-text);
+  color: var(--color-bg);
   text-decoration: none;
   border-radius: var(--radius-md);
   font-weight: var(--font-weight-bold);
@@ -38,9 +38,9 @@
 }
 
 .formLink:hover {
-  background: var(--gradient-primary-hover);
+  background-color: var(--color-secondary);
   transform: translateY(-2px);
-  box-shadow: 0 8px 16px rgba(102, 126, 234, 0.3);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.15);
 }
 
 .socialLinks {

--- a/src/app/projects/[id]/project-detail.module.css
+++ b/src/app/projects/[id]/project-detail.module.css
@@ -1,7 +1,7 @@
 .backLink {
   display: inline-flex;
   align-items: center;
-  color: var(--color-primary);
+  color: var(--text-secondary);
   text-decoration: none;
   font-weight: var(--font-weight-bold);
   margin-bottom: var(--spacing-lg);
@@ -9,7 +9,7 @@
 }
 
 .backLink:hover {
-  color: var(--color-secondary);
+  color: var(--text-primary);
   transform: translateX(-4px);
 }
 
@@ -22,10 +22,7 @@
   font-weight: var(--font-weight-bold);
   letter-spacing: -0.015em;
   margin-bottom: 0.5rem;
-  background: var(--gradient-primary);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  color: var(--text-primary);
 }
 
 .period {

--- a/src/app/projects/projects.module.css
+++ b/src/app/projects/projects.module.css
@@ -8,10 +8,7 @@
   font-weight: var(--font-weight-bold);
   letter-spacing: -0.015em;
   margin-bottom: 1rem;
-  background: var(--gradient-primary);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  color: var(--text-primary);
 }
 
 .description {
@@ -89,13 +86,13 @@
   gap: 0.25rem;
   font-size: 0.9rem;
   font-weight: var(--font-weight-bold);
-  color: var(--color-primary);
+  color: var(--text-primary);
   text-decoration: none;
   transition: all 0.2s ease;
 }
 
 .externalLink:hover {
-  color: var(--color-secondary);
+  color: var(--text-secondary);
   transform: translateY(-2px);
 }
 
@@ -115,7 +112,7 @@
 }
 
 .viewMore a:hover {
-  color: var(--color-primary);
+  color: var(--text-primary);
   transform: translateX(4px);
 }
 

--- a/src/components/floating-nav.module.css
+++ b/src/components/floating-nav.module.css
@@ -1,4 +1,4 @@
-/* Liquid Glass Floating Menu */
+/* Floating Menu */
 .container {
   position: fixed;
   bottom: var(--spacing-lg);
@@ -37,7 +37,7 @@
   -webkit-backdrop-filter: blur(20px) saturate(180%);
   border: 1px solid rgba(255, 255, 255, 0.2);
   box-shadow:
-    0 8px 32px 0 rgba(102, 126, 234, 0.15),
+    0 8px 32px 0 rgba(0, 0, 0, 0.1),
     inset 0 1px 1px 0 rgba(255, 255, 255, 0.3);
 
   animation: expandMenu 0.3s cubic-bezier(0.4, 0, 0.2, 1);
@@ -76,12 +76,11 @@
 }
 
 .navItem:hover {
-  background: rgba(102, 126, 234, 0.08);
-  color: var(--gradient-primary);
+  background: rgba(0, 0, 0, 0.05);
 }
 
 .navItem.active {
-  color: var(--color-primary);
+  color: var(--text-primary);
   font-weight: var(--font-weight-semibold);
   position: relative;
 }
@@ -94,7 +93,7 @@
   transform: translateY(-50%);
   width: 3px;
   height: 60%;
-  background: var(--gradient-primary);
+  background: var(--text-primary);
   border-radius: 2px;
 }
 
@@ -122,8 +121,7 @@
 }
 
 .themeButton:hover {
-  background: rgba(102, 126, 234, 0.08);
-  color: var(--color-primary);
+  background: rgba(0, 0, 0, 0.05);
 }
 
 .themeButton .icon {
@@ -158,7 +156,7 @@
   -webkit-backdrop-filter: blur(20px) saturate(180%);
   border: 1px solid rgba(255, 255, 255, 0.2);
   box-shadow:
-    0 8px 32px 0 rgba(102, 126, 234, 0.15),
+    0 8px 32px 0 rgba(0, 0, 0, 0.1),
     inset 0 1px 1px 0 rgba(255, 255, 255, 0.3);
 
   /* Minimum tap target size */
@@ -169,7 +167,7 @@
 .button:hover {
   transform: translateY(-2px) scale(1.02);
   box-shadow:
-    0 12px 40px 0 rgba(102, 126, 234, 0.25),
+    0 12px 40px 0 rgba(0, 0, 0, 0.15),
     inset 0 1px 1px 0 rgba(255, 255, 255, 0.4);
   background: rgba(255, 255, 255, 0.15);
 }
@@ -197,14 +195,14 @@
   background: rgba(31, 41, 55, 0.3);
   border: 1px solid rgba(255, 255, 255, 0.1);
   box-shadow:
-    0 8px 32px 0 rgba(102, 126, 234, 0.2),
+    0 8px 32px 0 rgba(0, 0, 0, 0.2),
     inset 0 1px 1px 0 rgba(255, 255, 255, 0.1);
 }
 
 :root[data-theme='dark'] .button:hover {
   background: rgba(31, 41, 55, 0.4);
   box-shadow:
-    0 12px 40px 0 rgba(102, 126, 234, 0.3),
+    0 12px 40px 0 rgba(0, 0, 0, 0.3),
     inset 0 1px 1px 0 rgba(255, 255, 255, 0.15);
 }
 
@@ -212,17 +210,16 @@
   background: rgba(31, 41, 55, 0.3);
   border: 1px solid rgba(255, 255, 255, 0.1);
   box-shadow:
-    0 8px 32px 0 rgba(102, 126, 234, 0.2),
+    0 8px 32px 0 rgba(0, 0, 0, 0.2),
     inset 0 1px 1px 0 rgba(255, 255, 255, 0.1);
 }
 
 :root[data-theme='dark'] .navItem:hover {
-  background: rgba(102, 126, 234, 0.1);
+  background: rgba(255, 255, 255, 0.05);
 }
 
 :root[data-theme='dark'] .themeButton:hover {
-  background: rgba(102, 126, 234, 0.1);
-  color: var(--color-primary);
+  background: rgba(255, 255, 255, 0.05);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -230,14 +227,14 @@
     background: rgba(31, 41, 55, 0.3);
     border: 1px solid rgba(255, 255, 255, 0.1);
     box-shadow:
-      0 8px 32px 0 rgba(102, 126, 234, 0.2),
+      0 8px 32px 0 rgba(0, 0, 0, 0.2),
       inset 0 1px 1px 0 rgba(255, 255, 255, 0.1);
   }
 
   :root:not([data-theme]) .button:hover {
     background: rgba(31, 41, 55, 0.4);
     box-shadow:
-      0 12px 40px 0 rgba(102, 126, 234, 0.3),
+      0 12px 40px 0 rgba(0, 0, 0, 0.3),
       inset 0 1px 1px 0 rgba(255, 255, 255, 0.15);
   }
 
@@ -247,12 +244,11 @@
   }
 
   :root:not([data-theme]) .navItem:hover {
-    background: rgba(102, 126, 234, 0.1);
+    background: rgba(255, 255, 255, 0.05);
   }
 
   :root:not([data-theme]) .themeButton:hover {
-    background: rgba(102, 126, 234, 0.1);
-    color: var(--color-primary);
+    background: rgba(255, 255, 255, 0.05);
   }
 }
 
@@ -278,6 +274,24 @@
 .themeButton:focus-visible {
   outline: none;
   box-shadow:
-    0 0 0 3px rgba(102, 126, 234, 0.3),
-    0 12px 40px 0 rgba(102, 126, 234, 0.25);
+    0 0 0 3px rgba(0, 0, 0, 0.5),
+    0 12px 40px 0 rgba(0, 0, 0, 0.1);
+}
+
+:root[data-theme='dark'] .button:focus-visible,
+:root[data-theme='dark'] .navItem:focus-visible,
+:root[data-theme='dark'] .themeButton:focus-visible {
+  box-shadow:
+    0 0 0 3px rgba(255, 255, 255, 0.6),
+    0 12px 40px 0 rgba(0, 0, 0, 0.2);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme]) .button:focus-visible,
+  :root:not([data-theme]) .navItem:focus-visible,
+  :root:not([data-theme]) .themeButton:focus-visible {
+    box-shadow:
+      0 0 0 3px rgba(255, 255, 255, 0.6),
+      0 12px 40px 0 rgba(0, 0, 0, 0.2);
+  }
 }

--- a/src/components/home/hero.module.css
+++ b/src/components/home/hero.module.css
@@ -19,8 +19,8 @@
 
 .profileImage {
   border-radius: 50%;
-  border: 4px solid var(--color-primary);
-  box-shadow: 0 10px 40px rgba(102, 126, 234, 0.4);
+  border: 4px solid var(--color-border);
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.15);
   animation: float 3s ease-in-out infinite;
 }
 
@@ -43,10 +43,7 @@
 }
 
 .gradient {
-  background: var(--gradient-primary);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  color: var(--text-primary);
 }
 
 .subtitle {

--- a/src/components/home/latest-posts.module.css
+++ b/src/components/home/latest-posts.module.css
@@ -61,7 +61,7 @@
   font-size: var(--font-size-lg);
   font-weight: var(--font-weight-bold);
   line-height: 1.5;
-  color: var(--color-primary);
+  color: var(--text-primary);
   text-decoration: none;
   transition: transform 0.2s ease;
 }

--- a/src/components/ui/badge.module.css
+++ b/src/components/ui/badge.module.css
@@ -17,30 +17,30 @@
   font-size: 0.875rem;
 }
 
-/* Variants */
+/* Variants - All monotone */
 .default {
   background-color: var(--badge-bg, #e5e7eb);
   color: var(--badge-text, #374151);
 }
 
 .primary {
-  background-color: #dbeafe;
-  color: #1e40af;
+  background-color: #e5e7eb;
+  color: #1f2937;
 }
 
 .success {
-  background-color: #d1fae5;
-  color: #065f46;
+  background-color: #d1d5db;
+  color: #111827;
 }
 
 .warning {
-  background-color: #fef3c7;
-  color: #92400e;
+  background-color: #f3f4f6;
+  color: #374151;
 }
 
 .info {
-  background-color: #e0e7ff;
-  color: #3730a3;
+  background-color: #d1d5db;
+  color: #1f2937;
 }
 
 [data-theme='dark'] .default {
@@ -49,21 +49,21 @@
 }
 
 [data-theme='dark'] .primary {
-  background-color: #1e3a8a;
-  color: #bfdbfe;
+  background-color: #374151;
+  color: #e5e7eb;
 }
 
 [data-theme='dark'] .success {
-  background-color: #064e3b;
-  color: #a7f3d0;
+  background-color: #4b5563;
+  color: #f3f4f6;
 }
 
 [data-theme='dark'] .warning {
-  background-color: #78350f;
-  color: #fde68a;
+  background-color: #374151;
+  color: #d1d5db;
 }
 
 [data-theme='dark'] .info {
-  background-color: #312e81;
-  color: #c7d2fe;
+  background-color: #4b5563;
+  color: #e5e7eb;
 }

--- a/src/components/ui/button.module.css
+++ b/src/components/ui/button.module.css
@@ -29,32 +29,32 @@
 
 /* Variants */
 .primary {
-  background: var(--gradient-primary);
-  color: white;
+  background-color: var(--color-text);
+  color: var(--color-bg);
 }
 
 .primary:hover {
-  background: var(--gradient-primary-hover);
+  background-color: var(--color-secondary);
 }
 
 .secondary {
-  background-color: var(--color-secondary);
-  color: white;
+  background-color: var(--color-text-light);
+  color: var(--color-bg);
 }
 
 .secondary:hover {
-  background-color: var(--color-secondary-dark);
+  background-color: var(--color-text);
 }
 
 .outline {
   background-color: transparent;
-  color: var(--color-primary);
-  border-color: var(--color-primary);
+  color: var(--color-text);
+  border-color: var(--color-border);
 }
 
 .outline:hover {
-  background-color: var(--color-primary);
-  color: white;
+  background-color: var(--color-text);
+  color: var(--color-bg);
 }
 
 /* Sizes */

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3,21 +3,17 @@
   /* Colors */
   --color-bg: #ffffff;
   --color-text: #1f2937;
-  --color-text-light: #4b5563;
-  --color-border: #d1d5db;
-  --color-primary: #667eea;
-  --color-secondary: #764ba2;
-  --color-secondary-dark: #5e3c82;
+  --color-text-light: #6b7280;
+  --color-border: #e5e7eb;
+  --color-primary: #1f2937;
+  --color-secondary: #374151;
+  --color-secondary-dark: #111827;
   --text-primary: #1f2937;
-  --text-secondary: #4b5563;
+  --text-secondary: #6b7280;
   --card-bg: #ffffff;
   --section-bg: #f9fafb;
   --nav-bg: rgba(255, 255, 255, 0.9);
-  --border-color: #d1d5db;
-
-  /* Gradients */
-  --gradient-primary: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  --gradient-primary-hover: linear-gradient(135deg, #5568d3 0%, #64408a 100%);
+  --border-color: #e5e7eb;
 
   /* 8pt Grid Spacing System */
   --spacing-xs: 8px;
@@ -53,12 +49,13 @@
 :root[data-theme='dark'] {
   --color-bg: #111827;
   --color-text: #f9fafb;
-  --color-text-light: #d1d5db;
+  --color-text-light: #9ca3af;
   --color-border: #374151;
-  --color-link: #60a5fa;
-  --color-link-hover: #3b82f6;
+  --color-primary: #e5e7eb;
+  --color-secondary: #d1d5db;
+  --color-secondary-dark: #f9fafb;
   --text-primary: #f9fafb;
-  --text-secondary: #d1d5db;
+  --text-secondary: #9ca3af;
   --card-bg: rgba(31, 41, 55, 0.5);
   --section-bg: rgba(31, 41, 55, 0.8);
   --nav-bg: rgba(17, 24, 39, 0.9);
@@ -69,11 +66,13 @@
   :root:not([data-theme]) {
     --color-bg: #111827;
     --color-text: #f9fafb;
-    --color-text-light: #d1d5db;
+    --color-text-light: #9ca3af;
     --color-border: #374151;
-
+    --color-primary: #e5e7eb;
+    --color-secondary: #d1d5db;
+    --color-secondary-dark: #f9fafb;
     --text-primary: #f9fafb;
-    --text-secondary: #d1d5db;
+    --text-secondary: #9ca3af;
     --card-bg: rgba(31, 41, 55, 0.5);
     --section-bg: rgba(31, 41, 55, 0.8);
     --nav-bg: rgba(17, 24, 39, 0.9);
@@ -199,7 +198,7 @@ footer a:not([class*='button']):not([class*='Link']):not([class*='link'])::after
 
 main a:not([class*='button']):not([class*='navLink']):not([class*='Link']):not([class*='link']):hover,
 footer a:not([class*='button']):not([class*='Link']):not([class*='link']):hover {
-  color: var(--color-secondary);
+  color: var(--text-primary);
 }
 
 main a:not([class*='button']):not([class*='navLink']):not([class*='Link']):not([class*='link']):hover::after,

--- a/src/styles/page-header.module.css
+++ b/src/styles/page-header.module.css
@@ -21,10 +21,7 @@
 }
 
 .titleGradient {
-  background: var(--gradient-primary);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  color: var(--text-primary);
 }
 
 .description {

--- a/src/styles/utils.module.css
+++ b/src/styles/utils.module.css
@@ -103,20 +103,5 @@
 
 .gradation {
   display: inline-block;
-  background: linear-gradient(45deg, #fa8bff 16%, #2bd2ff 57%, #2bff88 90%);
-  background: -webkit-linear-gradient(45deg, #fa8bff 16%, #2bd2ff 57%, #2bff88 90%);
-  background-clip: inherit;
-  background-size: 300% auto;
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  animation: gradientEffect 2.5s infinite alternate;
-}
-
-@keyframes gradientEffect {
-  from {
-    background-position: left;
-  }
-  to {
-    background-position: right;
-  }
+  color: var(--text-primary);
 }


### PR DESCRIPTION
## Summary
- サイト全体のカラーパレットを紫/青グラデーションから完全グレースケール（モノトーン）に変更
- グラデーションテキスト・ボタン・タイムラインなどを全てソリッドカラーに統一
- ライト/ダークテーマ切替、ホバーアニメーション、glassmorphism blur は控えめに維持

## 変更対象（12ファイル）
- `global.css`: CSS変数をグレースケールに再定義、グラデーション変数削除
- `button.module.css`: グラデーション → ソリッド黒/白ボタン
- `badge.module.css`: カラフルバリアント → グレースケール濃淡
- `floating-nav.module.css`: 紫 box-shadow → 中性色
- `hero.module.css`: グラデーションテキスト・プロフィール枠 → モノトーン
- `page-header.module.css` / `utils.module.css`: グラデーション削除
- `about.module.css`: タイムライン・技術タグ → モノトーン
- `projects.module.css` / `project-detail.module.css`: タイトル・リンク → モノトーン
- `contact.module.css`: フォームリンクボタン → ソリッド黒
- `latest-posts.module.css`: リンク色 → モノトーン

## Test plan
- [ ] `npm run build` 成功確認済み
- [ ] ライトモードで全ページの表示確認
- [ ] ダークモードで全ページの表示確認
- [ ] ホバーアニメーションが控えめに動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)